### PR TITLE
Speed up Bcrypt in tests

### DIFF
--- a/config/initializers/bcrypt.rb
+++ b/config/initializers/bcrypt.rb
@@ -1,0 +1,3 @@
+if Rails.env.test?
+  BCrypt::Engine.cost = BCrypt::Engine::MIN_COST
+end


### PR DESCRIPTION
Closes #5 

In the test environment, in the integration tests, we currently perform the real request to sign in users. As Bcrypt is designed to be slow, it slows our tests by a considerable amount.

To quick fix this, we set the minimum cost for Bcrypt in the test environment.